### PR TITLE
do not add MaxPermSize on java 8 and above

### DIFF
--- a/src/main/java/net/technicpack/minecraftcore/launch/MinecraftLauncher.java
+++ b/src/main/java/net/technicpack/minecraftcore/launch/MinecraftLauncher.java
@@ -95,12 +95,12 @@ public class MinecraftLauncher {
 		}
 		commands.add("-Xmx" + memory + "m");
 		if ( Float.parseFloat( System.getProperty( "java.class.version" ) ) < 52.0 ) {
-    		int permSize = 128;
-    		if (memory >= 2048) {
-    			permSize = 256;
-    		}
+			int permSize = 128;
+			if (memory >= 2048) {
+				permSize = 256;
+			}
+			commands.add("-XX:MaxPermSize=" + permSize + "m");
 		}
-		commands.add("-XX:MaxPermSize=" + permSize + "m");
 		commands.add("-Djava.library.path=" + new File(pack.getBinDir(), "natives").getAbsolutePath());
 		// Tell forge 1.5 to download from our mirror instead
 		commands.add("-Dfml.core.libraries.mirror=http://mirror.technicpack.net/Technic/lib/fml/%s");

--- a/src/main/java/net/technicpack/minecraftcore/launch/MinecraftLauncher.java
+++ b/src/main/java/net/technicpack/minecraftcore/launch/MinecraftLauncher.java
@@ -94,9 +94,11 @@ public class MinecraftLauncher {
 			commands.add("-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump");
 		}
 		commands.add("-Xmx" + memory + "m");
-		int permSize = 128;
-		if (memory >= 2048) {
-			permSize = 256;
+		if ( Float.parseFloat( System.getProperty( "java.class.version" ) ) < 52.0 ) {
+    		int permSize = 128;
+    		if (memory >= 2048) {
+    			permSize = 256;
+    		}
 		}
 		commands.add("-XX:MaxPermSize=" + permSize + "m");
 		commands.add("-Djava.library.path=" + new File(pack.getBinDir(), "natives").getAbsolutePath());


### PR DESCRIPTION
in java 8 is permgen replaced with metaspace and you don't need to modify it
